### PR TITLE
Import key types from IS.Optimization instead of redefining

### DIFF
--- a/src/InfrastructureOptimizationModels.jl
+++ b/src/InfrastructureOptimizationModels.jl
@@ -114,6 +114,14 @@ export ParameterKey
 export ExpressionKey
 export AuxVarKey
 
+# Abstract Key Types (from InfrastructureSystems.Optimization)
+export VariableType
+export ConstraintType
+export AuxVariableType
+export ParameterType
+export InitialConditionType
+export ExpressionType
+
 # Status Enums (from InfrastructureSystems)
 export ModelBuildStatus
 export RunStatus
@@ -144,19 +152,46 @@ import InfrastructureSystems: @assert_op, TableFormat, list_recorder_events, get
 
 # IS.Optimization imports: base types that remain in InfrastructureSystems
 # Note: ModelBuildStatus is aliased in definitions.jl, so don't import it directly
+# TODO: some of these are device specific enough to belong in POM.
 import InfrastructureSystems.Optimization:
     AbstractOptimizationContainer,
     OptimizationKeyType,
     AbstractModelStoreParams,
+    # Key types - imported from IS.Optimization to avoid duplication
+    VariableType,
+    ConstraintType,
+    AuxVariableType,
+    ParameterType,
+    InitialConditionType,
+    ExpressionType,
+    RightHandSideParameter,
+    ObjectiveFunctionParameter,
+    TimeSeriesParameter,
+    ConstructStage,
+    ArgumentConstructStage,
+    ModelConstructStage,
+    # Formulation abstract types
     AbstractDeviceFormulation,
+    AbstractServiceFormulation,
+    AbstractReservesFormulation,
+    AbstractThermalFormulation,
+    AbstractRenewableFormulation,
+    AbstractStorageFormulation,
+    AbstractLoadFormulation,
     AbstractHVDCNetworkModel,
-    AbstractPowerModel
-
+    AbstractPowerModel,
+    AbstractPTDFModel,
+    AbstractSecurityConstrainedPTDFModel,
+    AbstractActivePowerModel,
+    AbstractACPowerModel,
+    AbstractACPModel,
+    ACPPowerModel,
+    AbstractPowerFlowEvaluationModel,
+    AbstractPowerFlowEvaluationData
 
 import InfrastructureSystems:
     @scoped_enum,
     TableFormat,
-    get_results_base_power,
     get_variables,
     get_parameters,
     get_total_cost,
@@ -274,7 +309,9 @@ include("core/dataset_container.jl")
 include("core/results_by_time.jl")
 
 # Order Required
-include("core/power_flow_data_wrapper.jl")
+# Note: power_flow_data_wrapper.jl has been moved to PowerOperationsModels
+# as it depends on PowerFlows.jl types
+# include("core/power_flow_data_wrapper.jl")
 include("operation/problem_template.jl")
 include("core/optimization_container.jl")
 include("core/model_store_params.jl")

--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -259,7 +259,7 @@ function add_to_expression!(
     U <: ReactivePowerTimeSeriesParameter,
     V <: PSY.MotorLoad,
     W <: StaticPowerLoad,
-    X <: PM.ACPPowerModel,
+    X <: ACPPowerModel,
 }
     network_reduction = get_network_reduction(network_model)
     for d in devices
@@ -1572,7 +1572,7 @@ function add_to_expression!(
     U <: FlowActivePowerVariable,
     V <: PSY.ACBranch,
     W <: AbstractBranchFormulation,
-    X <: PM.AbstractActivePowerModel,
+    X <: AbstractActivePowerModel,
 }
     var = get_variable(container, U(), V)
     expression = get_expression(container, T(), PSY.ACBus)
@@ -1639,7 +1639,7 @@ function add_to_expression!(
     network_model::NetworkModel{U},
 ) where {
     W <: AbstractBranchFormulation,
-    U <: PM.AbstractActivePowerModel,
+    U <: AbstractActivePowerModel,
 }
     @debug "AreaInterchanges do not contribute to ActivePowerBalance expressions in non-area models."
     return
@@ -1905,7 +1905,7 @@ function add_to_expression!(
     ::Type{FlowActivePowerVariable},
     service::PSY.TransmissionInterface,
     model::ServiceModel{PSY.TransmissionInterface, V},
-    network_model::NetworkModel{<:PM.AbstractActivePowerModel},
+    network_model::NetworkModel{<:AbstractActivePowerModel},
 ) where {V <: Union{ConstantMaxInterfaceFlow, VariableMaxInterfaceFlow}}
     net_reduction_data = get_network_reduction(network_model)
     expression = get_expression(container, InterfaceTotalFlow(), PSY.TransmissionInterface)
@@ -2317,7 +2317,7 @@ function add_to_expression!(
 ) where {
     T <: ActivePowerBalance,
     U <: Union{SystemBalanceSlackUp, SystemBalanceSlackDown},
-    W <: PM.AbstractActivePowerModel,
+    W <: AbstractActivePowerModel,
 }
     variable = get_variable(container, U(), PSY.ACBus)
     expression = get_expression(container, T(), PSY.ACBus)

--- a/src/core/definitions.jl
+++ b/src/core/definitions.jl
@@ -5,7 +5,7 @@ abstract type AbstractAffectFeedforward end
 # Abstract type for sparse variables
 # Variables that subtype this use sparse arrays instead of dense arrays
 # This is used for piecewise linear variables and other sparse formulations
-# Note: VariableType is now defined locally in optimization_container_types.jl
+# Note: VariableType is imported from InfrastructureSystems.Optimization
 abstract type SparseVariableType <: VariableType end
 abstract type InterpolationVariableType <: SparseVariableType end
 abstract type BinaryInterpolationVariableType <: SparseVariableType end

--- a/src/core/device_model.jl
+++ b/src/core/device_model.jl
@@ -1,7 +1,7 @@
 """
 Formulation type to augment the power balance constraint expression with a time series parameter
 """
-struct FixedOutput <: IS.AbstractDeviceFormulation end
+struct FixedOutput <: AbstractDeviceFormulation end
 
 function _check_device_formulation(
     ::Type{D},

--- a/src/core/network_model.jl
+++ b/src/core/network_model.jl
@@ -11,9 +11,10 @@ function _check_pm_formulation(::Type{T}) where {T <: AbstractPowerModel}
     end
 end
 
-_maybe_flatten_pfem(pfem::Vector{PFS.PowerFlowEvaluationModel}) = pfem
-_maybe_flatten_pfem(pfem::PFS.PowerFlowEvaluationModel) =
-    PFS.flatten_power_flow_evaluation_model(pfem)
+# Note: PowerFlowEvaluationModel support has been moved to PowerOperationsModels
+# These stub functions maintain API compatibility
+_maybe_flatten_pfem(pfem::Vector) = pfem
+_maybe_flatten_pfem(pfem) = [pfem]
 
 """
 Establishes the NetworkModel for a given AC network formulation type.
@@ -37,7 +38,7 @@ Establishes the NetworkModel for a given AC network formulation type.
     subnetworks are inferred from PTDF/VirtualPTDF or discovered from the system.
 - `duals::Vector{DataType}` = Vector{DataType}()
     Constraint types for which duals should be recorded.
-- `power_flow_evaluation::Union{PFS.PowerFlowEvaluationModel, Vector{PFS.PowerFlowEvaluationModel}}`
+- `power_flow_evaluation::Union{AbstractPowerFlowEvaluationModel, Vector{<:AbstractPowerFlowEvaluationModel}}`
     Power-flow evaluation model(s). A single model is flattened to a vector internally.
 
 # Notes
@@ -64,7 +65,7 @@ mutable struct NetworkModel{T <: AbstractPowerModel}
     network_reduction::PNM.NetworkReductionData
     reduce_radial_branches::Bool
     reduce_degree_two_branches::Bool
-    power_flow_evaluation::Vector{PFS.PowerFlowEvaluationModel}
+    power_flow_evaluation::Vector{<:AbstractPowerFlowEvaluationModel}
     subsystem::Union{Nothing, String}
     hvdc_network_model::Union{Nothing, AbstractHVDCNetworkModel}
     modeled_branch_types::Vector{DataType}
@@ -80,9 +81,9 @@ mutable struct NetworkModel{T <: AbstractPowerModel}
         subnetworks = Dict{Int, Set{Int}}(),
         duals = Vector{DataType}(),
         power_flow_evaluation::Union{
-            PFS.PowerFlowEvaluationModel,
-            Vector{PFS.PowerFlowEvaluationModel},
-        } = PFS.PowerFlowEvaluationModel[],
+            AbstractPowerFlowEvaluationModel,
+            Vector{<:AbstractPowerFlowEvaluationModel},
+        } = AbstractPowerFlowEvaluationModel[],
         hvdc_network_model = nothing,
     ) where {T <: AbstractPowerModel}
         _check_pm_formulation(T)

--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -80,9 +80,9 @@ mutable struct OptimizationContainer <: AbstractOptimizationContainer
     model_base_power::Float64
     optimizer_stats::OptimizerStats
     built_for_recurrent_solves::Bool
-    metadata::ISOPT.OptimizationContainerMetadata
+    metadata::OptimizationContainerMetadata
     default_time_series_type::Type
-    power_flow_evaluation_data::Vector{PowerFlowEvaluationData}
+    power_flow_evaluation_data::Vector{<:AbstractPowerFlowEvaluationData}
 end
 
 function OptimizationContainer(
@@ -125,7 +125,7 @@ function OptimizationContainer(
         false,
         OptimizationContainerMetadata(),
         T,
-        Vector{PowerFlowEvaluationData}[],
+        AbstractPowerFlowEvaluationData[],
     )
 end
 
@@ -188,7 +188,7 @@ function has_container_key(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ExpressionType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -201,7 +201,7 @@ function has_container_key(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: VariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -214,7 +214,7 @@ function has_container_key(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: AuxVariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -227,7 +227,7 @@ function has_container_key(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ConstraintType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -240,7 +240,7 @@ function has_container_key(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ParameterType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -253,7 +253,7 @@ function has_container_key(
     container::OptimizationContainer,
     ::Type{T},
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: InitialConditionType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -454,7 +454,7 @@ function _make_system_expressions!(
     container::OptimizationContainer,
     subnetworks::Dict{Int, Set{Int}},
     ::Vector{Int},
-    ::Type{<:PM.AbstractActivePowerModel},
+    ::Type{<:AbstractActivePowerModel},
     bus_reduction_map::Dict{Int64, Set{Int64}},
 )
     time_steps = get_time_steps(container)
@@ -1105,7 +1105,7 @@ function add_variable_container!(
     ::Type{U},
     axs...;
     sparse = false,
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: VariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1138,7 +1138,7 @@ function add_variable_container!(
     container::OptimizationContainer,
     ::T,
     ::Type{U};
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: SparseVariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1166,7 +1166,7 @@ function get_variable(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta::String = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta::String = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: VariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1181,7 +1181,7 @@ function add_aux_variable_container!(
     ::Type{U},
     axs...;
     sparse = false,
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: AuxVariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1214,7 +1214,7 @@ function get_aux_variable(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta::String = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta::String = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: AuxVariableType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1229,7 +1229,7 @@ function add_dual_container!(
     ::Type{U},
     axs...;
     sparse = false,
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ConstraintType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1275,7 +1275,7 @@ function add_constraints_container!(
     ::Type{U},
     axs...;
     sparse = false,
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ConstraintType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1303,7 +1303,7 @@ function get_constraint(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta::String = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta::String = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ConstraintType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1585,7 +1585,7 @@ function get_parameter(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ParameterType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1631,7 +1631,7 @@ function get_parameter_array(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ParameterType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1642,7 +1642,7 @@ function get_parameter_multiplier_array(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ParameterType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1654,7 +1654,7 @@ function get_parameter_attributes(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ParameterType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1718,7 +1718,7 @@ function add_expression_container!(
     axs...;
     expr_type = GAE,
     sparse = false,
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ExpressionType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1775,7 +1775,7 @@ function get_expression(
     container::OptimizationContainer,
     ::T,
     ::Type{U},
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: ExpressionType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -1822,7 +1822,7 @@ function add_initial_condition_container!(
     ::T,
     ::Type{U},
     axs;
-    meta = ISOPT.CONTAINER_KEY_EMPTY_META,
+    meta = CONTAINER_KEY_EMPTY_META,
 ) where {
     T <: InitialConditionType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
@@ -2208,7 +2208,7 @@ function lazy_container_addition!(
     T <: ConstraintType,
     U <: Union{IS.InfrastructureSystemsComponent, IS.InfrastructureSystemsContainer},
 }
-    meta = get(kwargs, :meta, ISOPT.CONTAINER_KEY_EMPTY_META)
+    meta = get(kwargs, :meta, CONTAINER_KEY_EMPTY_META)
     if !has_container_key(container, T, U, meta)
         cons_container =
             add_constraints_container!(container, constraint, U, axs...; kwargs...)

--- a/src/core/optimization_container_metadata.jl
+++ b/src/core/optimization_container_metadata.jl
@@ -1,5 +1,5 @@
 const _CONTAINER_METADATA_FILE = "optimization_container_metadata.bin"
-
+# TODO: IS has the same definition. Where does it belong, here or in IS?
 struct OptimizationContainerMetadata
     container_key_lookup::Dict{String, <:OptimizationContainerKey}
 end

--- a/src/core/optimization_container_types.jl
+++ b/src/core/optimization_container_types.jl
@@ -1,15 +1,10 @@
-# Base types are imported from InfrastructureSystems.Optimization in the main module:
-# - AbstractOptimizationContainer
-# - OptimizationKeyType
+# Key types are imported from InfrastructureSystems.Optimization in the main module:
+# - AbstractOptimizationContainer, OptimizationKeyType
+# - VariableType, ConstraintType, AuxVariableType, ParameterType, InitialConditionType, ExpressionType
+# - RightHandSideParameter, ObjectiveFunctionParameter, TimeSeriesParameter
+# - ConstructStage, ArgumentConstructStage, ModelConstructStage
 
-# Extend OptimizationKeyType with concrete subtypes
-abstract type VariableType <: OptimizationKeyType end
-abstract type ConstraintType <: OptimizationKeyType end
-abstract type AuxVariableType <: OptimizationKeyType end
-abstract type ParameterType <: OptimizationKeyType end
-abstract type InitialConditionType <: OptimizationKeyType end
-abstract type ExpressionType <: OptimizationKeyType end
-
+# Utility functions for the imported types
 convert_result_to_natural_units(::Type{<:VariableType}) = false
 convert_result_to_natural_units(::Type{<:ConstraintType}) = false
 convert_result_to_natural_units(::Type{<:AuxVariableType}) = false
@@ -22,16 +17,3 @@ should_write_resulting_value(::Type{<:AuxVariableType}) = true
 should_write_resulting_value(::Type{<:ExpressionType}) = false
 # TODO: Piecewise linear parameter are broken to write
 should_write_resulting_value(::Type{<:ParameterType}) = false
-
-abstract type RightHandSideParameter <: ParameterType end
-abstract type ObjectiveFunctionParameter <: ParameterType end
-
-abstract type TimeSeriesParameter <: RightHandSideParameter end
-
-"""
-Optimization Container construction stage
-"""
-abstract type ConstructStage end
-
-struct ArgumentConstructStage <: ConstructStage end
-struct ModelConstructStage <: ConstructStage end

--- a/src/initial_conditions/initialization.jl
+++ b/src/initial_conditions/initialization.jl
@@ -17,8 +17,8 @@ function get_initial_conditions_template(model::OperationModel, number_of_steps:
     network_model.network_reduction =
         deepcopy(get_network_reduction(get_network_model(model.template)))
     network_model.subnetworks = get_subnetworks(get_network_model(model.template))
-    # Initialization does not support PowerFlow evaluation
-    network_model.power_flow_evaluation = Vector{PFS.PowerFlowEvaluationModel}[]
+    # Initialization does not support PowerFlow evaluation - use empty vector
+    network_model.power_flow_evaluation = AbstractPowerFlowEvaluationModel[]
     bus_area_map = get_bus_area_map(get_network_model(model.template))
 
     if !isempty(bus_area_map)

--- a/src/operation/problem_template.jl
+++ b/src/operation/problem_template.jl
@@ -5,13 +5,13 @@ const ServicesModelContainer = Dict{Tuple{String, Symbol}, ServiceModel}
 abstract type AbstractProblemTemplate end
 
 """
-    ProblemTemplate(::Type{T}) where {T<:PM.AbstractPowerFormulation}
+    ProblemTemplate(::Type{T}) where {T<:AbstractPowerModel}
 
 Creates a model reference of the InfrastructureOptimizationModels Optimization Problem.
 
 # Arguments
 
-  - `model::Type{T<:PM.AbstractPowerFormulation}`:
+  - `model::Type{T<:AbstractPowerModel}`:
 
 # Example
 


### PR DESCRIPTION
Compatibility with PR [543](https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/543) in IS: some type definitions have been moved around, or given abstract supertypes in IS.

> - Import VariableType, ConstraintType, etc. from IS.Optimization
> - Keep utility functions (convert_result_to_natural_units, should_write_resulting_value) in IOM
> - Update references to use local CONTAINER_KEY_EMPTY_META
> - Add re-exports for key types
> 
