### PR TITLE
Support scalar time-series cost params (shut_down/no_load) in unwrap_for_param

### DIFF
--- a/src/objective_function/value_curve_cost.jl
+++ b/src/objective_function/value_curve_cost.jl
@@ -391,6 +391,17 @@ get_max_tranches(data::AbstractDict) = maximum(get_max_tranches.(values(data)))
 # parameters.
 unwrap_for_param(::ParameterType, ts_elem, expected_axs) = ts_elem
 
+# Scalar-linear cost time series (shut-down / no-load and other scalar cost fields
+# of a time-series offer cost, incremental or decremental): the resolved per-hour
+# element is an `IS.LinearFunctionData` whose proportional term carries the scalar
+# cost. This mirrors the static path's `_shutdown_cost_value(::IS.LinearCurve)`
+# extraction. Return the scalar so the parameter container is filled with a
+# `Float64` (its `size` is `()`, matching the empty additional-axes of a scalar
+# parameter). Without this method the element falls through the identity above and
+# `_size_wrapper` then calls `size(::LinearFunctionData)`, which has no method.
+unwrap_for_param(::ParameterType, ts_elem::IS.LinearFunctionData, expected_axs) =
+    IS.get_proportional_term(ts_elem)
+
 # For piecewise data the number of tranches can vary over time, so the parameter
 # container is sized for the maximum number of tranches and shorter curves are
 # padded. We pad with "degenerate" tranches at the top end of the curve with


### PR DESCRIPTION
## Summary

Adds the missing `unwrap_for_param` method for **scalar-linear** time-series cost parameters, so a `MarketBidTimeSeriesCost` (and `ImportExportTimeSeriesCost`) can be built under a unit-commitment model. Today the time-varying **PWL offer-curve** parameters are handled, but the **scalar** cost fields (`shut_down`, `no_load`, cost-at-min) are not.

## Problem

When a device carries a time-series offer cost, POM adds `ShutdownCostParameter` / `NoLoadCostParameter` as time-series parameters. Their per-hour value resolves to an `IS.LinearFunctionData`. `unwrap_for_param` has methods only for `AbstractPiecewiseLinearSlopeParameter` / `AbstractPiecewiseLinearBreakpointParameter` over `IS.PiecewiseStepData`, so the scalar element falls through to the identity method and `_size_wrapper` then calls `size(::LinearFunctionData)`, which has no method — failing the parameter-population assert in POM `add_parameters.jl`.

Minimal repro: build any UC `DecisionModel` over a `ThermalStandard` whose `operation_cost` is a `MarketBidTimeSeriesCost`. `build!` returns `FAILED` with `MethodError: no method matching size(::LinearFunctionData)`.

## Fix

Add one additive method that extracts the scalar from the per-hour `LinearFunctionData` via `IS.get_proportional_term` — mirroring how the static path already reads a scalar `LinearCurve` cost (`_shutdown_cost_value(::IS.LinearCurve) = IS.get_proportional_term(x)`). The returned `Float64` has `size () == ()`, satisfying the existing assert.

```julia
unwrap_for_param(::ParameterType, ts_elem::IS.LinearFunctionData, expected_axs) =
    IS.get_proportional_term(ts_elem)
```

Dispatching on the element type covers all scalar cost parameters (shut_down / no_load / cost-at-min, incremental and decremental) in one method, with no signature changes to existing code.

## Verification

Verified end-to-end with the downstream POM change (Sienna-Platform/PowerOperationsModels.jl device time-varying market-bid PR): a 24h time-varying `MarketBidTimeSeriesCost` UC now `build!`s and `solve!`s, and the per-hour objective coefficients match the per-hour offer-curve slopes exactly (validated on both synthetic and real ERCOT DAM data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
