### PR TITLE
Fix show(::OptimizationProblemOutputs) for single-period results

### DIFF
--- a/src/utils/print_pt_v3.jl
+++ b/src/utils/print_pt_v3.jl
@@ -218,17 +218,21 @@ function _show_method(
 ) where {T <: OptimizationProblemOutputs}
     timestamps = get_timestamps(outputs)
 
+    # `get_resolution` returns `nothing` when there is a single timestamp (no
+    # interval to diff), so guard against `Dates.Minute(nothing)`.
+    resolution = get_resolution(outputs)
+    resolution_str =
+        isnothing(resolution) ? "N/A (single period)" :
+        string(Dates.Minute(resolution))
+
     if backend == :html
         println(io, "<p> Start: $(first(timestamps))</p>")
         println(io, "<p> End: $(last(timestamps))</p>")
-        println(
-            io,
-            "<p> Resolution: $(Dates.Minute(get_resolution(outputs)))</p>",
-        )
+        println(io, "<p> Resolution: $(resolution_str)</p>")
     else
         println(io, "Start: $(first(timestamps))")
         println(io, "End: $(last(timestamps))")
-        println(io, "Resolution: $(Dates.Minute(get_resolution(outputs)))")
+        println(io, "Resolution: $(resolution_str)")
     end
 
     values = Dict{String, Vector{String}}(

--- a/test/test_optimization_outputs.jl
+++ b/test/test_optimization_outputs.jl
@@ -154,6 +154,12 @@ import InfrastructureSystems as IS
     @test IOM.get_resolution(opt_res1) == Millisecond(3600000)
     @test IOM.get_resolution(opt_res2) == Millisecond(3600000)
     @test isnothing(IOM.get_resolution(opt_res3))
+
+    # Regression: showing outputs with a single time period used to throw
+    # `MethodError: no method matching Minute(::Nothing)` because the resolution
+    # is `nothing` when there is only one timestamp.
+    @test occursin("N/A (single period)", sprint(show, MIME("text/plain"), opt_res3))
+    @test occursin("Resolution: 60 minutes", sprint(show, MIME("text/plain"), opt_res1))
 end
 
 @testset "Test OptimizationProblemOutputs 3d long format" begin


### PR DESCRIPTION
## Problem
Printing `OptimizationProblemOutputs` (formerly `OptimizationProblemResults`) for a `DecisionModel` with a single time period threw:

```
ERROR: MethodError: no method matching Minute(::Nothing)
```

`_show_method` blindly wraps `get_resolution(outputs)` in `Dates.Minute(...)`, but `get_resolution` derives the resolution by diffing the timestamps and returns `nothing` when there's only one timestamp (nothing to diff).

## Fix
Compute the resolution string once in `_show_method`, guarding the `nothing` case (prints `N/A (single period)`), and reuse it in both the `:html` and `:plain` branches.

## Test
Adds a regression test on the existing single-timestamp `opt_res3` fixture in `test/test_optimization_outputs.jl`, asserting `show` no longer throws and emits the fallback string.

Verified locally: the two new assertions pass and the crash is gone. (Note: this test file has 10 pre-existing, unrelated `read_variable`/`read_expression` failures on `main` — not touched here.)

Fixes Sienna-Platform/PowerOperationsModels.jl#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)