### PR TITLE
Use FunctionData get_domain in is_nontrivial_offer

### DIFF
--- a/src/objective_function/common.jl
+++ b/src/objective_function/common.jl
@@ -140,7 +140,7 @@ function _onvar_cost(
 )
     value_curve = IS.get_value_curve(cost_function)
     cost_component = IS.get_function_data(value_curve)
-    # Always in \$/h
+    # Cost at zero output (y-intercept), always in \$/h.
     constant_term = IS.get_constant_term(cost_component)
     return constant_term
 end

--- a/src/objective_function/value_curve_cost.jl
+++ b/src/objective_function/value_curve_cost.jl
@@ -173,8 +173,8 @@ Is this offer curve carrying meaningful data, as opposed to the default
 `MarketBidCost` / `ImportExportCost`? Only used for load formulations.
 """
 function is_nontrivial_offer(curve::IS.CostCurve{IS.PiecewiseIncrementalCurve})
-    xs = IS.get_x_coords(IS.get_function_data(IS.get_value_curve(curve)))
-    return last(xs) > first(xs)
+    lo, hi = IS.get_domain(IS.get_function_data(IS.get_value_curve(curve)))
+    return hi > lo
 end
 # A TS-backed offer side is the absent/placeholder side of a one-sided participant
 # (a load with no supply offer, or a generator with no demand offer) when it carries a


### PR DESCRIPTION
Adopts the `FunctionData` sugar from [InfrastructureSystems PR #492](https://github.com/Sienna-Platform/InfrastructureSystems.jl/pull/492):

- `is_nontrivial_offer` now uses `IS.get_domain` instead of hand-pulling x-coords and comparing `first`/`last`.
- Clarifies the `_onvar_cost` comment (the constant term is the cost at zero output, i.e. the y-intercept).

Behavior-preserving syntactic cleanup. Part of a linked pair with the PowerOperationsModels PR for NREL-Sienna/PowerOperationsModels.jl#33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)