### PR TITLE
Reject 1D dense/sparse containers at creation (issue #15)

### DIFF
--- a/src/core/optimization_container.jl
+++ b/src/core/optimization_container.jl
@@ -586,6 +586,18 @@ function deserialize_metadata!(
     return
 end
 
+"""
+Reject 1D dense/sparse JuMP containers (issue #15): variable/constraint/expression/dual
+containers must always be indexable as `x[i, j]`, never as a bare vector `x[i]`. Containers
+with 3+ dimensions (e.g. PWL sparse containers keyed on `(name, segment, time)`) are fine.
+"""
+function _check_container_dims(key::OptimizationContainerKey, value)
+    if value isa Union{JuMP.Containers.DenseAxisArray, JuMP.Containers.SparseAxisArray}
+        IS.@assert_op ndims(value) >= 2
+    end
+    return
+end
+
 # PERF: compilation hotspot. from string conversion at the container[key] = value line?
 function _assign_container!(container::OrderedDict, key::OptimizationContainerKey, value)
     if haskey(container, key)
@@ -594,6 +606,7 @@ function _assign_container!(container::OrderedDict, key::OptimizationContainerKe
         )
         throw(IS.InvalidValue("$key is already stored"))
     end
+    _check_container_dims(key, value)
     container[key] = value
     @debug "Added container entry $(typeof(key)) $(encode_key(key))" _group =
         LOG_GROUP_OPTIMIZATION_CONTAINER
@@ -878,6 +891,8 @@ function add_param_container_shared_axes!(
         param_array = DenseAxisArray{param_type}(undef, axs...)
         multiplier_array = fill!(DenseAxisArray{Float64}(undef, axs...), NaN)
     end
+    _check_container_dims(key, param_array)
+    _check_container_dims(key, multiplier_array)
     param_container = ParameterContainer(attribute, param_array, multiplier_array)
     _assign_container!(container.parameters, key, param_container)
     return param_container

--- a/test/test_optimization_container.jl
+++ b/test/test_optimization_container.jl
@@ -38,6 +38,38 @@ struct MockExpressionType <: ISOPT.ExpressionType end
         @test isempty(IOM.get_expressions(container))
     end
 
+    @testset "1D containers are rejected (issue #15)" begin
+        mock_sys = MockSystem(100.0)
+        settings = IOM.Settings(
+            mock_sys;
+            horizon = Dates.Hour(24),
+            resolution = Dates.Hour(1),
+            time_series_cache_size = 0,  # Bypass stores_time_series_in_memory check
+        )
+        container = IOM.OptimizationContainer(
+            mock_sys,
+            settings,
+            nothing,
+            MockDeterministic,
+        )
+        IOM.set_time_steps!(container, 1:24)
+        device_names = ["gen1", "gen2"]
+
+        # Passing a single axis (no time dimension) must fail, not silently build a Vector.
+        @test_throws Exception IOM.add_variable_container!(
+            container,
+            IOM.ActivePowerVariable,
+            MockComponentType,
+            device_names,
+        )
+        @test_throws Exception IOM.add_constraints_container!(
+            container,
+            MockConstraintType,
+            MockComponentType,
+            device_names,
+        )
+    end
+
     @testset "add_variable_container!" begin
         mock_sys = MockSystem(100.0)
         settings = IOM.Settings(


### PR DESCRIPTION
## Summary
- Fixes #15: variable/constraint/aux-variable/dual/expression/parameter containers must always be indexable as `x[i, j]`, never as a bare vector `x[i]`.
- Adds `_check_container_dims`, wired into the `_assign_container!` choke point (covers variables, aux variables, constraints, duals, expressions) and into `add_param_container_shared_axes!` (param/multiplier arrays). Throws if a `DenseAxisArray`/`SparseAxisArray` ends up with `ndims < 2`. Containers with 3+ dims (e.g. PWL sparse containers keyed on `(name, segment, time)`) are unaffected.
- `add_param_container_split_axes!` needed no change — it always appends `time_steps`, so it's structurally ≥2D already.
- Added a regression test asserting that passing a single axis to `add_variable_container!`/`add_constraints_container!` now throws.

Audited every container-creation call site in IOM's own `src/` — none currently build a 1D container, so this is a pure guardrail against future/downstream regressions (the bug pattern that motivated the issue lives in downstream packages like StorageSystemsSimulations.jl and POM).

## Test plan
- [x] `julia --project=test test/runtests.jl` — 1333/1333 passing, Aqua clean
- [x] Formatter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)